### PR TITLE
update to 1.21.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ gradle-app.setting
 # gradle/wrapper/gradle-wrapper.properties
 
 .idea
+
+.vscode

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ apply plugin: "java-library"
 apply plugin: "maven-publish"
 
 ext.majorVersion = 8
-ext.minorVersion = 5
-ext.minecraftVersion = "1.21.1"
+ext.minorVersion = 6
+ext.minecraftVersion = "1.21.8"
 sourceCompatibility = 21
 targetCompatibility = 21
 
@@ -31,18 +31,18 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:22.0.0'
 
     // spigot
-    compileOnly "org.spigotmc:spigot-api:$minecraftVersion-R0.1-SNAPSHOT"
-
+    // compileOnly "org.spigotmc:spigot-api:$minecraftVersion-R0.1-SNAPSHOT"
+    compileOnly "io.papermc.paper:paper-api:$minecraftVersion-R0.1-SNAPSHOT"
     // other nyaa plugins
-    compileOnly('cat.nyaa:nyaacore:9.4')
-    compileOnly('cat.nyaa:ecore:0.3.4')
+    compileOnly('cat.nyaa:nyaacore:9.10')
+    compileOnly('cat.nyaa:ecore:0.3.5')
 
 
     // 3rd party plugins
-    compileOnly('net.essentialsx:EssentialsX:2.20.1')
+    compileOnly('net.essentialsx:EssentialsX:2.21.2')
 
-    // annotation processor
-    annotationProcessor "org.spigotmc:spigot-api:$minecraftVersion-R0.1-SNAPSHOT"
+    // // annotation processor
+    // annotationProcessor "org.spigotmc:spigot-api:$minecraftVersion-R0.1-SNAPSHOT"
 }
 
 // publications


### PR DESCRIPTION
The new version of EssentialsX depends on the Paper API, so the Spigot API has been replaced with the Paper API to resolve dependency conflicts.
Upgraded to 1.21.8
Updated other NyaaCat dependencies to the latest versions.